### PR TITLE
Error handling and bug fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ readFile("lastlength", function read(err, data) {
     lastLength = data
   } else if(err.code == "ENOENT") {
     writeFileSync("lastlength", "0")
+    lastLength = 0
   } else {
     console.log("Error with lastlength: ", err.code)
   }
@@ -43,10 +44,16 @@ function checkGame() {
         .then(body => {
           if (body.Success){
             console.log("Success: " + asfcommand)
+            console.debug(body)
             writeFileSync("lastlength", lastLength.toString())
           } else {
-            console.log("Error: " + body)
+            console.log("Error: ")
+            console.log(body)
           }
+        })
+        .catch(err => {
+          console.log(`error running '${command}':`)
+          console.log(err)
         })
     } else {
       console.log("Found: " + codes.length + " and has: " + lastLength)


### PR DESCRIPTION
If the request fails to go through (timeout, refused, etc), log it. Also log the error body if ASF deems it an invalid request (before it was just printing `[object Object]`). Finally, if the lastlength file doesn't exist, explicitly set it to zero in memory. 

Dockerized in `herocc/archisteamfarm:asfclaim`, but don't rely on this one long-term as I use it for testing new versions locally.