### PR TITLE
Tag docker images with git tag, branch, and ref

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,7 +73,7 @@ jobs:
             # pull request event
             type=ref,enable=true,prefix=pr-,suffix=,event=pr
             # commit sha
-            type=sha,format=short
+            type=sha,prefix=,suffix=,format=short
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,6 +65,15 @@ jobs:
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # branch event
+            type=ref,enable=true,event=branch
+            # tag event
+            type=ref,enable=true,event=tag
+            # pull request event
+            type=ref,enable=true,prefix=pr-,suffix=,event=pr
+            # commit sha
+            type=sha,format=short
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
Currently, all docker images are pushed with the same tag `master`. This makes it difficult to reference specific versions. This PR will automatically label generated images with the name of the branch `master`, the tag (if it exists), and the exact commit hash sha.