### PR TITLE
Add Optional GitHub Token Authentication to Prevent Rate Limiting

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,12 @@
+# GitHub Personal Access Token (required)
+# Generate at: https://github.com/settings/tokens
+# Requires 'gist' scope to read gists
+GITHUB_TOKEN=your_github_token_here
+
+# ASF Configuration (optional)
 ASF_PORT=1242
 ASF_HOST=localhost
-ASF_PASSWORD=hunter2
+ASF_PASSWORD=
 ASF_COMMAND_PREFIX=!
 ASF_HTTPS=false
-ASF_BOTS=asf #https://github.com/JustArchiNET/ArchiSteamFarm/wiki/Commands#bots-argument
+ASF_BOTS=asf

--- a/.env.template
+++ b/.env.template
@@ -8,7 +8,7 @@ GITHUB_TOKEN=your_github_token_here
 # ASF Configuration (optional)
 ASF_PORT=1242
 ASF_HOST=localhost
-ASF_PASSWORD=
+ASF_PASSWORD=hunter2
 ASF_COMMAND_PREFIX=!
 ASF_HTTPS=false
 ASF_BOTS=asf # https://github.com/JustArchiNET/ArchiSteamFarm/wiki/Commands#bots-argument

--- a/.env.template
+++ b/.env.template
@@ -11,4 +11,4 @@ ASF_HOST=localhost
 ASF_PASSWORD=
 ASF_COMMAND_PREFIX=!
 ASF_HTTPS=false
-ASF_BOTS=asf
+ASF_BOTS=asf # https://github.com/JustArchiNET/ArchiSteamFarm/wiki/Commands#bots-argument

--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,6 @@
-# GitHub Personal Access Token (required)
+# GitHub Personal Access Token (optional but recommended)
+# Without a token, you may hit GitHub's rate limits (60 requests/hour)
+# With a token, you get 5,000 requests/hour
 # Generate at: https://github.com/settings/tokens
 # Requires 'gist' scope to read gists
 GITHUB_TOKEN=your_github_token_here

--- a/README.md
+++ b/README.md
@@ -11,20 +11,21 @@ Latest games claimed: https://gist.github.com/C4illin/77a4bcb9a9a7a95e5f291badc9
 
 ## Install
 1. enable IPC in ASF (https://github.com/JustArchiNET/ArchiSteamFarm/wiki/IPC), by default it is enabled (also add password to .env if not empty)
-2. Create a GitHub Personal Access Token:
+2. install node.js (v18 or later)
+3. `git clone https://github.com/C4illin/ASFclaim.git`
+4. `cd ASFclaim`
+5. `npm install`
+6. **(Optional but recommended)** Create a GitHub Personal Access Token to avoid rate limits:
    - Go to https://github.com/settings/tokens
    - Click "Generate new token" → "Generate new token (classic)"
    - Give it a name like "ASFclaim"
    - Select the `gist` scope (required to read gists)
    - Copy the generated token
-3. install node.js (v18 or later)
-4. `git clone https://github.com/C4illin/ASFclaim.git`
-5. `cd ASFclaim`
-6. `npm install`
-7. Create a `.env` file with your GitHub token:
-   ```
-   GITHUB_TOKEN=your_github_token_here
-   ```
+   - Create a `.env` file with your GitHub token:
+     ```
+     GITHUB_TOKEN=your_github_token_here
+     ```
+   - **Rate limits**: Without token: 60 requests/hour | With token: 5,000 requests/hour
 
 ## Run
 1. Make sure ASF is running
@@ -34,7 +35,11 @@ The program checks available licenses every 6 hours.
 ### Docker
 
 ```bash
+# With GitHub token (recommended):
 docker run --name asfclaim -e GITHUB_TOKEN=your_github_token_here -e ASF_PORT=1242 -e ASF_HOST=localhost -e ASF_HTTPS=false -e ASF_PASSWORD=hunter2 -e ASF_COMMAND_PREFIX=! -e ASF_BOTS=asf ghcr.io/c4illin/asfclaim:master
+
+# Without GitHub token (may hit rate limits):
+docker run --name asfclaim -e ASF_PORT=1242 -e ASF_HOST=localhost -e ASF_HTTPS=false -e ASF_PASSWORD=hunter2 -e ASF_COMMAND_PREFIX=! -e ASF_BOTS=asf ghcr.io/c4illin/asfclaim:master
 ```
 #### Docker-compose:
 ```yml
@@ -47,7 +52,7 @@ services:
     restart: unless-stopped
     depends_on: asf # remove this if asf is not running in docker
     environment:
-      - GITHUB_TOKEN=${GITHUB_TOKEN} # required - get from https://github.com/settings/tokens
+      - GITHUB_TOKEN=${GITHUB_TOKEN} # optional but recommended - prevents rate limiting
       # all below are optional, defaults are listed
       - ASF_PORT=1242
       - ASF_HOST=localhost

--- a/README.md
+++ b/README.md
@@ -11,20 +11,30 @@ Latest games claimed: https://gist.github.com/C4illin/77a4bcb9a9a7a95e5f291badc9
 
 ## Install
 1. enable IPC in ASF (https://github.com/JustArchiNET/ArchiSteamFarm/wiki/IPC), by default it is enabled (also add password to .env if not empty)
-2. install node.js (v18 or later)
-3. `git clone https://github.com/C4illin/ASFclaim.git`
-4. `cd ASFclaim`
-5. `npm install`
+2. Create a GitHub Personal Access Token:
+   - Go to https://github.com/settings/tokens
+   - Click "Generate new token" → "Generate new token (classic)"
+   - Give it a name like "ASFclaim"
+   - Select the `gist` scope (required to read gists)
+   - Copy the generated token
+3. install node.js (v18 or later)
+4. `git clone https://github.com/C4illin/ASFclaim.git`
+5. `cd ASFclaim`
+6. `npm install`
+7. Create a `.env` file with your GitHub token:
+   ```
+   GITHUB_TOKEN=your_github_token_here
+   ```
 
 ## Run
 1. Make sure ASF is running
 2. `node .`
-The program checks available licenses every 6 hours. 
+The program checks available licenses every 6 hours.
 
 ### Docker
 
 ```bash
-docker run --name asfclaim -e ASF_PORT=1242 -e ASF_HOST=localhost -e ASF_HTTPS=false -e ASF_PASSWORD=hunter2 -e ASF_COMMAND_PREFIX=! -e ASF_BOTS=asf ghcr.io/c4illin/asfclaim:master 
+docker run --name asfclaim -e GITHUB_TOKEN=your_github_token_here -e ASF_PORT=1242 -e ASF_HOST=localhost -e ASF_HTTPS=false -e ASF_PASSWORD=hunter2 -e ASF_COMMAND_PREFIX=! -e ASF_BOTS=asf ghcr.io/c4illin/asfclaim:master
 ```
 #### Docker-compose:
 ```yml
@@ -36,7 +46,9 @@ services:
     container_name: asfclaim
     restart: unless-stopped
     depends_on: asf # remove this if asf is not running in docker
-    environment: # all are optional, defaults are listed below
+    environment:
+      - GITHUB_TOKEN=${GITHUB_TOKEN} # required - get from https://github.com/settings/tokens
+      # all below are optional, defaults are listed
       - ASF_PORT=1242
       - ASF_HOST=localhost
       - ASF_PASSWORD=
@@ -64,6 +76,6 @@ https://github.com/specu/ASFclaim.py Python rewrite without any dependencies
 https://github.com/JourneyDocker/ASFclaim fork with different gist and discord notifications
 
 Instead of forking it, please consider sending a PR so we can make the best solution together!
-                        
+
 ## Stargazers over time
 [![Stargazers over time](https://starchart.cc/C4illin/ASFclaim.svg?variant=adaptive)](https://starchart.cc/C4illin/ASFclaim)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   asf-claim:
     build: .
     environment:
-      - GITHUB_TOKEN=${GITHUB_TOKEN}
+      # - GITHUB_TOKEN=${GITHUB_TOKEN}  # optional: prevents rate limiting
       # - ASF_PORT=1242
       # - ASF_HOST=localhost
       # - ASF_PASSWORD=hunter2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ version: "3"
 services:
   asf-claim:
     build: .
-    # environment:
+    environment:
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
       # - ASF_PORT=1242
       # - ASF_HOST=localhost
       # - ASF_PASSWORD=hunter2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   asf-claim:
     build: .
-    environment:
+    # environment:
       # - GITHUB_TOKEN=${GITHUB_TOKEN}  # optional: prevents rate limiting
       # - ASF_PORT=1242
       # - ASF_HOST=localhost

--- a/index.js
+++ b/index.js
@@ -53,9 +53,8 @@ function checkGame() {
 				asfcommand = asfcommand.slice(0, -1);
 
 				const command = { Command: asfcommand };
-				const url = `http${
-					asfhttps ? "s" : ""
-				}://${asfhost}:${asfport}/Api/Command`;
+				const url = `http${asfhttps ? "s" : ""
+					}://${asfhost}:${asfport}/Api/Command`;
 				const headers = { "Content-Type": "application/json" };
 				if (password && password.length > 0) {
 					headers.Authentication = password;

--- a/index.js
+++ b/index.js
@@ -5,9 +5,14 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 const githubToken = process.env.GITHUB_TOKEN;
-const octokit = new Octokit({
-	auth: githubToken,
-});
+const octokit = new Octokit(githubToken ? { auth: githubToken } : {});
+
+if (githubToken) {
+	console.log("✓ GitHub token provided - using authenticated requests (5000/hour rate limit)");
+} else {
+	console.log("⚠ No GitHub token provided - using unauthenticated requests (60/hour rate limit)");
+	console.log("  Consider setting GITHUB_TOKEN environment variable to avoid rate limits");
+}
 
 const asfport = process.env.ASF_PORT || "1242";
 const asfhost = process.env.ASF_HOST || "localhost";
@@ -53,8 +58,9 @@ function checkGame() {
 				asfcommand = asfcommand.slice(0, -1);
 
 				const command = { Command: asfcommand };
-				const url = `http${asfhttps ? "s" : ""
-					}://${asfhost}:${asfport}/Api/Command`;
+				const url = `http${
+					asfhttps ? "s" : ""
+				}://${asfhost}:${asfport}/Api/Command`;
 				const headers = { "Content-Type": "application/json" };
 				if (password && password.length > 0) {
 					headers.Authentication = password;

--- a/index.js
+++ b/index.js
@@ -2,8 +2,12 @@ import fetch from "node-fetch";
 import { readFile, writeFileSync } from "node:fs";
 import { Octokit } from "@octokit/rest";
 import * as dotenv from "dotenv";
-const octokit = new Octokit();
 dotenv.config();
+
+const githubToken = process.env.GITHUB_TOKEN;
+const octokit = new Octokit({
+	auth: githubToken,
+});
 
 const asfport = process.env.ASF_PORT || "1242";
 const asfhost = process.env.ASF_HOST || "localhost";

--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ const githubToken = process.env.GITHUB_TOKEN;
 const octokit = new Octokit(githubToken ? { auth: githubToken } : {});
 
 if (githubToken) {
-	console.log("✓ GitHub token provided - using authenticated requests (5000/hour rate limit)");
+	console.log("GitHub token provided - using authenticated requests (5000/hour rate limit)");
 } else {
-	console.log("⚠ No GitHub token provided - using unauthenticated requests (60/hour rate limit)");
-	console.log("  Consider setting GITHUB_TOKEN environment variable to avoid rate limits");
+	console.log("No GitHub token provided - using unauthenticated requests (60/hour rate limit)");
+	console.log("Consider setting GITHUB_TOKEN environment variable to avoid rate limits");
 }
 
 const asfport = process.env.ASF_PORT || "1242";


### PR DESCRIPTION
Good morning,

I've been experiencing a number of HTTP 401 errors from gist which results in my docker container crashing. 

This PR adds optional support for github api token to increase rate limits.